### PR TITLE
fix: corrige erro no arquivo global css (#5)

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -8,7 +8,7 @@
     --foreground: 0 0% 3.9%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
-    --popover: 0 0% 100
+    --popover: 0 0% 100;
     --popover-foreground: 0 0% 3.9%;
     --primary: 0 72.2% 50.6%;
     --primary-foreground: 0 85.7% 97.3%;


### PR DESCRIPTION
Este PR corrige o bug descrito na issue #5, onde o campo de busca estava com o background transparent.

Ajustes feitos no arquivo global.css